### PR TITLE
Hotfix for settings.py unable to run on devs machine

### DIFF
--- a/backend/kuvein/settings.py
+++ b/backend/kuvein/settings.py
@@ -135,8 +135,9 @@ DATABASES = {
     }
 }
 
-if 'ca.pem' in os.listdir('kuvein'):
+if 'ca.pem' in os.listdir(os.path.join(BASE_DIR, 'kuvein')):
     DATABASES['default']['OPTIONS'] = {'ssl': {'ca': os.path.join(os.path.dirname(__file__), 'ca.pem')}}
+
 
 # Password validation
 # https://docs.djangoproject.com/en/5.1/ref/settings/#auth-password-validators


### PR DESCRIPTION
a lot of devs encountered a bug where os.listdir() would throw error when given only a directory name (not full path )